### PR TITLE
Separate FCS and SCS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# {Semi, Fully} Custom Servo
-The embedded code for custom/semi-custom servo goes here.
-
+# Semi Custom Servo
+The embedded code for semi-custom servo goes here.
 
 # L432_Helper
 Custom servo firmware. Poorly named (please someone fix it!).


### PR DESCRIPTION
The SCS and FCS codebases don't really have anything in common, so to avoid accidental changes to the wrong codebase (if we separated by subdirectories) or pushing the wrong branch (if we separated by branches), I figured it might be a good idea to just work on separate repos. Open to thoughts. The latest code for FCS has just been version controlled and is living at <https://github.com/utra-robosoccer/soccer-fully-custom-servo>